### PR TITLE
Fix zsvjmp for ppc64le.

### DIFF
--- a/zdojmp.c
+++ b/zdojmp.c
@@ -12,6 +12,6 @@ void zdojmp_ (long *jmpbuf, long *status) {
     int stat = *status ? *status : 1;
     long *status_ptr = ((long **)jmpbuf)[0];
     void *jb = (long **)jmpbuf+1;
- //   *status_ptr = stat;
+    *status_ptr = stat;
     siglongjmp (jb, stat);
 }

--- a/zsvjmp-ppc64el.s
+++ b/zsvjmp-ppc64el.s
@@ -1,25 +1,21 @@
-	.file	"zsvjmp.s"
-
+	.file "zsvjmp.s"
 	.abiversion 2
-	.section	".text"
+	.section ".text"
 	.align 2
 	.globl zsvjmp_
-	.type	zsvjmp_, @function
+	.type zsvjmp_, @function
+
 zsvjmp_:
-	# R3 = buf, R4 = &status
-	li   11,0        # r11 = 0
-	std  11,0(4)     # *status = r11
-	std  4,0(3)      # buf[0] = status (as arg)
-	addi 3,3,8       # &buf[1] --> 1st arg for sigsetjmp (Buf)
-	li   4,0         # 0       --> 2nd arg for sigsetjmp (savesigs)
-	mflr 11
-	std  11, -8(1)     # Save on the read zone
-	addi 1, 1, -8    # create a small frame
-	bl    __sigsetjmp
+	# r3 = jmpbuf, r4 = &status
+	li 9,0		# r9 = 0
+	std 9,0(4)	# *status = r9
+	std 4,0(3)	# buf[0] = status (as arg)
+	addi 3,3,8	# &buf[1] --> 1st arg for sigsetjmp (Buf)
+	li 4,0		# 0 --> 2nd arg for sigsetjmp (savesigs)  
+	mflr 14		# save LR in r14 (r14 is saved in jmpbuf)
+	bl __sigsetjmp
 	nop
-	ld 11, 0(1)     # Recover from the read zone
-	mtlr 11		# Restore lr
-	addi 1, 1, 8    # Remove our mini frame
-	blr
-	.size	zsvjmp_,.-zsvjmp_
-	.section	.note.GNU-stack,"",@progbits
+	mtlr 14		# restore LR
+
+	.size zsvjmp_,.-zsvjmp_
+	.section .note.GNU-stack,"",@progbits


### PR DESCRIPTION
Summary:

This commit fixes zsvjmp for ppc64le. Before call a __sigsetjmp from a shared
lib we must save LR so siglongjmp can jump in the right place. The problem is
that we must call a shared function using bl instruction that overwrites LR
register. The solution here saves LR in r14 and restore it back when __sigsetjmp
returns as r14 (nonvolatile) is saved on jmpbuf by __sigsetjmp.